### PR TITLE
Social media icons in footer are misaligned

### DIFF
--- a/src/app/models/social-media.model.ts
+++ b/src/app/models/social-media.model.ts
@@ -12,7 +12,7 @@ export const enum SocialMediaIcons {
   LinkedIn = 'fab fa-linkedin',
   WhatsApp = 'fab fa-whatsapp',
   GitHub = 'fab fa-github',
-  Email = 'fab fa-envelope',
+  Email = 'fas fa-envelope',
   Facebook = 'fab fa-facebook',
   YouTube = 'fab fa-youtube',
   Instagram = 'fab fa-instagram',


### PR DESCRIPTION
Fixes #54

## Description

This task consists in correcting the not appearing and/or misalignment of the e-mail icon. It's important because all the social media icons should appear and be aligned, so that, the site users can find them and contact us. 

## Changes

In order complete the task, I propose the following changes:

 - Changing `fab fa-envelope` to  `fas fa-envelope` in Email section of SocialMediaIcons in `social-media.model.ts`

## Relevant screenshots

### Before

![image](https://user-images.githubusercontent.com/85318137/151003016-db377486-9fe6-4a33-b265-773191209c29.png)

### After

![image](https://user-images.githubusercontent.com/85318137/151002076-bc05f563-dabd-4757-b664-2deba0662286.png)
