### PR TITLE
 Refactor SocialMediaService.formatSocialMedia

### DIFF
--- a/src/app/core/footer/footer.component.ts
+++ b/src/app/core/footer/footer.component.ts
@@ -1,28 +1,21 @@
-import { Component, OnInit } from '@angular/core'
+import { Component } from '@angular/core'
 import { SocialMedia, SocialMediaModel } from '@models'
-import { SocialMediaService } from '@services'
 
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.scss'],
 })
-export class FooterComponent implements OnInit {
+export class FooterComponent {
   socialMedia: SocialMediaModel[] = [
-    { name: SocialMedia.Email, url: 'sasel@eesc.usp.br' },
     { name: SocialMedia.Facebook, url: 'https://www.facebook.com/sasel.usp' },
-    { name: SocialMedia.GitHub, url: 'https://github.com/sa-sel' },
     { name: SocialMedia.Instagram, url: 'https://www.instagram.com/saselusp/' },
     { name: SocialMedia.WhatsApp, url: '+55 (71) 8155-6248' },
+    { name: SocialMedia.Email, url: 'sasel@eesc.usp.br' },
     {
       name: SocialMedia.YouTube,
       url: 'https://www.youtube.com/channel/UCCIw2l3rNCepuZsugA4BC7w',
     },
+    { name: SocialMedia.GitHub, url: 'https://github.com/sa-sel' },
   ]
-
-  constructor(private socialMediaService: SocialMediaService) {}
-
-  ngOnInit(): void {
-    this.socialMedia = this.socialMediaService.formatSocialMedia(this.socialMedia)
-  }
 }

--- a/src/app/models/social-media.model.ts
+++ b/src/app/models/social-media.model.ts
@@ -1,34 +1,34 @@
 export enum SocialMedia {
-  LinkedIn = 'LinkedIn',
-  WhatsApp = 'WhatsApp',
-  GitHub = 'GitHub',
+  Discord = 'Discord',
   Email = 'Email',
   Facebook = 'Facebook',
-  YouTube = 'YouTube',
+  GitHub = 'GitHub',
   Instagram = 'Instagram',
-  Discord = 'Discord',
+  LinkedIn = 'LinkedIn',
+  WhatsApp = 'WhatsApp',
+  YouTube = 'YouTube',
 }
 
 export const enum SocialMediaIcons {
-  LinkedIn = 'fab fa-linkedin',
-  WhatsApp = 'fab fa-whatsapp',
-  GitHub = 'fab fa-github',
+  Discord = 'fab fa-discord',
   Email = 'fas fa-envelope',
   Facebook = 'fab fa-facebook',
-  YouTube = 'fab fa-youtube',
+  GitHub = 'fab fa-github',
   Instagram = 'fab fa-instagram',
-  Discord = 'fab fa-discord',
+  LinkedIn = 'fab fa-linkedin',
+  WhatsApp = 'fab fa-whatsapp',
+  YouTube = 'fab fa-youtube',
 }
 
 export const SocialMediaIconMap: Record<SocialMedia, SocialMediaIcons> = {
-  [SocialMedia.LinkedIn]: SocialMediaIcons.LinkedIn,
-  [SocialMedia.WhatsApp]: SocialMediaIcons.WhatsApp,
-  [SocialMedia.GitHub]: SocialMediaIcons.GitHub,
+  [SocialMedia.Discord]: SocialMediaIcons.Discord,
   [SocialMedia.Email]: SocialMediaIcons.Email,
   [SocialMedia.Facebook]: SocialMediaIcons.Facebook,
-  [SocialMedia.YouTube]: SocialMediaIcons.YouTube,
+  [SocialMedia.GitHub]: SocialMediaIcons.GitHub,
   [SocialMedia.Instagram]: SocialMediaIcons.Instagram,
-  [SocialMedia.Discord]: SocialMediaIcons.Discord,
+  [SocialMedia.LinkedIn]: SocialMediaIcons.LinkedIn,
+  [SocialMedia.WhatsApp]: SocialMediaIcons.WhatsApp,
+  [SocialMedia.YouTube]: SocialMediaIcons.YouTube,
 }
 
 export interface SocialMediaModel {

--- a/src/app/services/social-media.service.ts
+++ b/src/app/services/social-media.service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable class-methods-use-this */
+
 import { Injectable } from '@angular/core'
 import { SocialMedia, SocialMediaIconMap, SocialMediaModel } from '@models'
 
@@ -5,18 +7,6 @@ import { SocialMedia, SocialMediaIconMap, SocialMediaModel } from '@models'
   providedIn: 'root',
 })
 export class SocialMediaService {
-  // Order is important
-  availableNetworks = [
-    SocialMedia.Facebook,
-    SocialMedia.Instagram,
-    SocialMedia.WhatsApp,
-    SocialMedia.Email,
-    SocialMedia.YouTube,
-    SocialMedia.GitHub,
-    SocialMedia.LinkedIn,
-    SocialMedia.Discord,
-  ]
-
   private getWhatsAppURL(phoneNumber: string, message: string): string {
     const apiURL = 'https://api.whatsapp.com/send?phone=$PHONE&text=$MESSAGE'
 
@@ -47,20 +37,11 @@ export class SocialMediaService {
     /* eslint-enable no-undef */
   }
 
-  formatSocialMedia(socialNetworks: SocialMediaModel[]): SocialMediaModel[] {
-    const index = (networkName: SocialMedia) =>
-      this.availableNetworks.indexOf(networkName)
-
-    return socialNetworks
-      .filter(network => network.url && this.availableNetworks.includes(network.name))
-      .map(
-        network =>
-          <SocialMediaModel>{
-            name: network.name,
-            url: this.getLink(network, 'Olá, SA-SEL! Tudo bem?'),
-            icon: SocialMediaIconMap[network.name],
-          }
-      )
-      .sort((a, b) => index(a.name) - index(b.name))
+  format(network: SocialMediaModel): SocialMediaModel {
+    return {
+      name: network.name,
+      url: this.getLink(network, 'Olá, SA-SEL! Tudo bem?'),
+      icon: SocialMediaIconMap[network.name],
+    }
   }
 }

--- a/src/app/shared/social-media-icon/social-media-icon.component.ts
+++ b/src/app/shared/social-media-icon/social-media-icon.component.ts
@@ -22,6 +22,7 @@ export class SocialMediaIconComponent implements OnInit {
       this.colorClass = ''
     }
 
+    this.network = this.socialMediaService.format(this.network)
     this.tooltip = this.socialMediaService.getTooltipText()
   }
 


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #64

## Description

<!-- Describe what exactly you made (the task) and why it's important -->
It's just internal improvements to make the code more intuitive, so now the social media in the footer are rendered in the order they are defined, instead of being reordered by a service.

Now the service is also better encapsulated, only being injected into `SocialMediaIconComponent`, instead of also it's parent component. This way, each instance of `SocialMediaIconComponent` works on it's own and can be used independently of anything else.

When creating a social media icon, you only need to specify the social media's name and URL.

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - `SocialMediaService.formatSocialMedia` (now `SocialMediaService.format`) receives and return only one `SocialMediaModel`
 - `SocialMediaService.availableNetworks` was deleted because it's no longer necessary