### PR TITLE
Make footer stay at the bottom when the page content doesn't have enough height

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,68 +1,70 @@
 <app-banner [image]="image1"></app-banner>
 <app-navbar></app-navbar>
-<div>
-  <main style="min-height: calc(100vh - 230px); margin-top: 85px" class="container">
-    <app-title>Titulo</app-title>
-    <app-title [subtitle]="true">Subtitulo</app-title>
+<main
+  class="container"
+  style="min-height: calc(100vh + 20px - {{ footerElement.offsetHeight }}px)"
+>
+  <app-title>Titulo</app-title>
+  <app-title [subtitle]="true">Subtitulo</app-title>
 
-    <app-alternating-layout [contents]="textAndImageList"> </app-alternating-layout>
+  <app-alternating-layout [contents]="textAndImageList"> </app-alternating-layout>
 
-    <h2 class="mb-5">oi</h2>
-    <h2>oi</h2>
-    <h2>oi</h2>
-    <h2>oi</h2>
-    <h2>oi</h2>
-    <h2>oi</h2>
-    <h2>oi</h2>
+  <h2 class="mb-5">oi</h2>
+  <h2>oi</h2>
+  <h2>oi</h2>
+  <h2>oi</h2>
+  <h2>oi</h2>
+  <h2>oi</h2>
+  <h2>oi</h2>
 
-    <button (click)="toggleModal()">testeste</button>
-    <app-title>{{ openModal }}</app-title>
+  <button (click)="toggleModal()">testeste</button>
+  <app-title>{{ openModal }}</app-title>
 
-    <app-modal
-      [(isOpen)]="openModal"
-      title="Esse é um modal"
-      [text]="'Oi! teste'"
-      [image]="{ src: '../../assets/images/logo/logo.png', alt: 'test' }"
-      url="https://google.com"
-    >
-      <div class="text-justify">
-        <br />
-        <app-title>Content Projection</app-title>
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
-        Ipsum has been the industrys standard dummy text ever since the 1500s, when an
-        unknown printer took a galley of type and scrambled it to make a type specimen
-        book.
-        <br /><br />
-        It has survived not only five centuries, but also the leap into electronic
-        typesetting, remaining essentially unchanged.
-        <br /><br />
-        It was popularised in the 1960s with the release of Letraset sheets containing
-        Lorem Ipsum passages, and more recently with desktop publishing software like
-        Aldus PageMaker including versions of Lorem Ipsum Lorem Ipsum is simply dummy text
-        of the printing and typesetting industry. Lorem Ipsum has been the industrys
-        standard dummy text ever since the 1500s, when an unknown printer took a galley of
-        type and scrambled it to make a type specimen book.
-        <br /><br />
-        It has survived not only five centuries, but also the leap into electronic
-        typesetting, remaining essentially unchanged.
-        <br /><br />
-        It was popularised in the 1960s with the release of Letraset sheets containing
-        Lorem Ipsum passages, and more recently with desktop publishing software like
-        Aldus PageMaker including versions of Lorem Ipsum Lorem Ipsum is simply dummy text
-        of the printing and typesetting industry. Lorem Ipsum has been the industrys
-        standard dummy text ever since the 1500s, when an unknown printer took a galley of
-        type and scrambled it to make a type specimen book.
-        <br /><br />
-        It has survived not only five centuries, but also the leap into electronic
-        typesetting, remaining essentially unchanged.
-        <br /><br />
-        It was popularised in the 1960s with the release of Letraset sheets containing
-        Lorem Ipsum passages, and more recently with desktop publishing software like
-        Aldus PageMaker including versions of Lorem Ipsum
-      </div>
-    </app-modal>
+  <app-modal
+    [(isOpen)]="openModal"
+    title="Esse é um modal"
+    [text]="'Oi! teste'"
+    [image]="{ src: '../../assets/images/logo/logo.png', alt: 'test' }"
+    url="https://google.com"
+  >
+    <div class="text-justify">
+      <br />
+      <app-title>Content Projection</app-title>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+      Ipsum has been the industrys standard dummy text ever since the 1500s, when an
+      unknown printer took a galley of type and scrambled it to make a type specimen book.
+      <br /><br />
+      It has survived not only five centuries, but also the leap into electronic
+      typesetting, remaining essentially unchanged.
+      <br /><br />
+      It was popularised in the 1960s with the release of Letraset sheets containing Lorem
+      Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum Lorem Ipsum is simply dummy text of the
+      printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy
+      text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book.
+      <br /><br />
+      It has survived not only five centuries, but also the leap into electronic
+      typesetting, remaining essentially unchanged.
+      <br /><br />
+      It was popularised in the 1960s with the release of Letraset sheets containing Lorem
+      Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum Lorem Ipsum is simply dummy text of the
+      printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy
+      text ever since the 1500s, when an unknown printer took a galley of type and
+      scrambled it to make a type specimen book.
+      <br /><br />
+      It has survived not only five centuries, but also the leap into electronic
+      typesetting, remaining essentially unchanged.
+      <br /><br />
+      It was popularised in the 1960s with the release of Letraset sheets containing Lorem
+      Ipsum passages, and more recently with desktop publishing software like Aldus
+      PageMaker including versions of Lorem Ipsum
+    </div>
+  </app-modal>
 
-    <router-outlet></router-outlet>
-  </main>
+  <router-outlet></router-outlet>
+</main>
+<div #footerElement>
+  <app-footer></app-footer>
 </div>
-<app-footer style="margin-top: auto"></app-footer>


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #42 

## Description
Currently, if there isn't enough content between header and footer, when full-scrolling down, part of the banner will still be visible. With the following changes, there will always be at least a full-screen space between header and footer, independent of the amount of content in the page. 
<!-- Describe what exactly you made (the task) and why it's important -->

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - Adition of min-vh-100 class to main tag in app.component.html

<!-- If the task's result is visual enough (e.g. making a new screen), add a screenshot here so everyone can see it. If not, delete the following line.-->
## Relevant screenshots
Before:
![image](https://user-images.githubusercontent.com/70351552/151237450-8b629a3c-4220-42ae-8fe5-b418f21948eb.png)

After:
![image](https://user-images.githubusercontent.com/70351552/151237375-8b3a21b2-f086-4988-98ba-4301ba078703.png)
![image](https://user-images.githubusercontent.com/70351552/151237403-ec2b4039-c955-45a7-8d2c-fcac791da61e.png)
