### PR TITLE
When scrolling out of the banner, the navbar covers the top of the page body

### DIFF
--- a/src/app/core/footer/footer.component.html
+++ b/src/app/core/footer/footer.component.html
@@ -18,7 +18,7 @@
       </div>
     </section>
 
-    <section class="text-gray-500 text-center text-justify pt-3 px-5">
+    <section class="text-gray-500 text-center pt-3 px-5">
       <p>
         © 2022 SA-SEL. Todos os direitos reservados. <br class="d-md-none" />
         Desenvolvido por

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -42,12 +42,22 @@ export class NavbarComponent implements OnInit, OnDestroy {
   private setSticky() {
     const navbar = this.navbarRef?.nativeElement
     navbar.classList.add('fixed-top')
-    document.body.style.paddingTop = `${navbar.offsetHeight}px` // eslint-disable-line
+
+    // eslint-disable-next-line
+    const main = document.querySelector('main') || document.querySelector('.main')
+    if (main) {
+      main.style.paddingTop = `${navbar.offsetHeight + 20}px`
+    }
   }
 
   private unsetSticky() {
     const navbar = this.navbarRef?.nativeElement
     navbar.classList.remove('fixed-top')
-    document.body.style.paddingTop = '0' // eslint-disable-line
+
+    // eslint-disable-next-line
+    const main = document.querySelector('main') || document.querySelector('.main')
+    if (main) {
+      main.style.paddingTop = '0'
+    }
   }
 }


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #70 

## Description

<!-- Describe what exactly you made (the task) and why it's important -->
After scrolling away from the banner, the navbar was covering the top of the page body. This PR fixes it.

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - Add a padding to the `<main>` when the navbar gets fixed at the top

<!-- If the task's result is visual enough (e.g. making a new screen), add a screenshot here so everyone can see it. If not, delete the following line.-->
## Relevant screenshots
![footer](https://user-images.githubusercontent.com/23108450/151271584-185ffe9e-7b45-4d8b-9962-83aaf281f175.gif)

