### PR TITLE
 Banner/navbar glitch in Brave mobile

### DIFF
--- a/src/app/shared/banner/banner.component.html
+++ b/src/app/shared/banner/banner.component.html
@@ -1,6 +1,6 @@
 <div class="m-0 p-0 w-100 h-100">
   <div class="banner-container">
-    <div class="bg-dark w-100 h-100"></div>
+    <div class="bg-dark"></div>
 
     <div
       *ngIf="background.length == 1; else carouselBlock"

--- a/src/app/shared/banner/banner.component.scss
+++ b/src/app/shared/banner/banner.component.scss
@@ -1,6 +1,7 @@
 @import '../../../colors';
 
 .banner-bg {
+  width: 100%;
   height: 100vh;
   background-repeat: no-repeat;
   background-color: $black;
@@ -11,6 +12,8 @@
 }
 
 .banner-container .bg-dark {
+  width: 100%;
+  height: 100vh;
   opacity: 0.55;
   position: absolute;
   z-index: 1;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,7 +56,7 @@ body,
   background-color: $light;
   font-family: 'Ubuntu', -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI',
     'Roboto', 'Oxygen';
-  height: 100%;
+  height: 100vh;
 }
 
 a,


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #102 

## Description

<!-- Describe what exactly you made (the task) and why it's important -->
Previously the banner was glitching in the Brave app for Android (mobile device) and overlapping with the page body.

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - Make the body's height occupy all of the viewport
   - I'm not sure **why** this fixes the glitch, but it appears to do so
   - https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser

<!-- If the task's result is visual enough (e.g. making a new screen), add a screenshot here so everyone can see it. If not, delete the following line.-->
## Relevant screenshots
![image](https://user-images.githubusercontent.com/23108450/152234803-1585ad2e-c2d7-4de5-97d8-3c1910c0e1b9.png)
![image](https://user-images.githubusercontent.com/23108450/152234972-4560b736-c5f6-4b59-99b8-bb26e8346ac4.png)
![image](https://user-images.githubusercontent.com/23108450/152235013-ed25fe34-9699-4e6d-b0a2-63937a36f3d7.png)