### PR TITLE
Update all <a> and <img>

### DIFF
--- a/src/app/core/bandejao/bandejao.component.ts
+++ b/src/app/core/bandejao/bandejao.component.ts
@@ -1,5 +1,5 @@
-import { AlternatingLayoutModel } from './../../models/alternating-layout.model'
 import { Component } from '@angular/core'
+import { AlternatingLayoutModel } from './../../models/alternating-layout.model'
 
 @Component({
   selector: 'app-bandejao',
@@ -39,7 +39,7 @@ export class BandejaoComponent {
         src: '/assets/images/bandejao/marmita.png',
         caption: 'Marmitas servidas durante a pandemia',
       },
-      text: 'Você pode consultar o cardápio do dia pelo <a target="_blank" rel="noopener noreferrer" href="http://www.puspsc.usp.br/cardapio/">site da prefeitura do campus</a>, pelo aplicativo <a target="_blank" rel="noopener noreferrer" href="https://sites.usp.br/sas/exemplo-de-post-2/">Cardápio USP</a>, ou até mesmo por um <a href="https://t.me/BandejaoBot">bot no telegram</a>.<br><br>Durante o período de pandemia o bandejão está sendo oferecido por meio de marmitas. Medidas de segurança como oferecimento de álcool em gel e distanciamento estão sendo seguidas.<br><br>Estudantes com dificuldades socioeconômicas podem acessar o auxílio alimentação oferecido pela <a target="_blank" rel="noopener noreferrer" href="http://www.puspsc.usp.br/bolsas-e-auxilios/">prefeitura do campus</a>',
+      text: 'Você pode consultar o cardápio do dia pelo <a target="_blank" rel="noopener noreferrer" href="http://www.puspsc.usp.br/cardapio/">site da prefeitura do campus</a>, pelo aplicativo <a target="_blank" rel="noopener noreferrer" href="https://sites.usp.br/sas/exemplo-de-post-2/">Cardápio USP</a>, ou até mesmo por um <a href="https://t.me/BandejaoBot" target="_blank" rel="noreferrer noopener">bot no telegram</a>.<br><br>Durante o período de pandemia o bandejão está sendo oferecido por meio de marmitas. Medidas de segurança como oferecimento de álcool em gel e distanciamento estão sendo seguidas.<br><br>Estudantes com dificuldades socioeconômicas podem acessar o auxílio alimentação oferecido pela <a target="_blank" rel="noopener noreferrer" href="http://www.puspsc.usp.br/bolsas-e-auxilios/">prefeitura do campus</a>',
     },
   ]
 }

--- a/src/app/core/home/home.component.html
+++ b/src/app/core/home/home.component.html
@@ -15,7 +15,7 @@
   [(isOpen)]="openModal"
   title="Esse é um modal"
   [text]="'Oi! teste'"
-  [image]="{ src: '../../assets/images/logo/logo.png', alt: 'test', caption: 'Teste' }"
+  [image]="{ src: '/assets/images/logo/main.svg', alt: 'test', caption: 'Teste' }"
   url="https://google.com"
 >
   <div class="text-justify">

--- a/src/app/core/matricula/matricula.component.html
+++ b/src/app/core/matricula/matricula.component.html
@@ -9,7 +9,7 @@
   <img
     src="/assets/images/matricula/fluxograma.png"
     alt="Fluxograma: Convoações, Matrícula e Lista de Espera"
-    class="img-fluid d-block mx-auto my-2 w-100 w-lg-50"
+    class="d-block mx-auto my-2 w-100 w-lg-50"
   />
 </section>
 

--- a/src/app/shared/alternating-layout/alternating-layout.component.html
+++ b/src/app/shared/alternating-layout/alternating-layout.component.html
@@ -3,7 +3,7 @@
     <!--Only image-->
     <div *ngIf="item.image && !item.text">
       <figure class="m-0">
-        <img [src]="item.image.src" [alt]="item.image.alt" class="w-100" />
+        <img [src]="item.image.src" [alt]="item.image.alt" />
         <figcaption>{{ item.image.caption }}</figcaption>
       </figure>
     </div>
@@ -26,7 +26,7 @@
           [ngClass]="item.imageOnLeft ? 'float-md-start' : 'order-md-2 float-md-end'"
         >
           <figure class="m-0">
-            <img [src]="item.image.src" [alt]="item.image.alt" class="w-100" />
+            <img [src]="item.image.src" [alt]="item.image.alt" />
             <figcaption>{{ item.image.caption }}</figcaption>
           </figure>
         </div>

--- a/src/app/shared/banner/banner.component.html
+++ b/src/app/shared/banner/banner.component.html
@@ -25,6 +25,6 @@
   </div>
 
   <div class="logo-container w-50">
-    <img *ngIf="logo" [src]="logo.src" [alt]="logo.alt" class="w-100" />
+    <img *ngIf="logo" [src]="logo.src" [alt]="logo.alt" />
   </div>
 </div>

--- a/src/app/shared/image-grid/image-grid.component.html
+++ b/src/app/shared/image-grid/image-grid.component.html
@@ -3,7 +3,7 @@
     <div *ngIf="!item.modal; else showModal">
       <figure class="d-block m-auto">
         <a [href]="item.url" target="_blank" rel="noreferrer noopener">
-          <img [src]="item.image.src" [alt]="item.image.alt" class="w-100" />
+          <img [src]="item.image.src" [alt]="item.image.alt" />
         </a>
         <figcaption>{{ item.image.caption }}</figcaption>
       </figure>
@@ -15,7 +15,7 @@
           (click)="createModal(item.modal!)"
           [src]="item.image.src"
           [alt]="item.image.alt"
-          class="w-100 cursor-pointer"
+          class="cursor-pointer"
         />
         <figcaption>{{ item.image.caption }}</figcaption>
       </figure>

--- a/src/app/shared/logo/logo.component.html
+++ b/src/app/shared/logo/logo.component.html
@@ -1,5 +1,1 @@
-<img
-  class="d-inline-block align-middle m-auto img-fluid"
-  [src]="path"
-  alt="Logo da SA-SEL"
-/>
+<img class="d-inline-block align-middle m-auto" [src]="path" alt="Logo da SA-SEL" />

--- a/src/app/shared/modal/modal.component.html
+++ b/src/app/shared/modal/modal.component.html
@@ -14,20 +14,22 @@
   <div class="modal-body">
     <!-- image + link -->
     <figure class="mt-2 mb-4" *ngIf="url && image">
-      <a [href]="url" target="__blank">
-        <img [src]="image?.src" [alt]="image?.alt" class="w-100 image-responsive" />
+      <a [href]="url" target="_blank" rel="noreferrer noopener">
+        <img [src]="image?.src" [alt]="image?.alt" />
       </a>
       <figcaption>{{ image?.caption }}</figcaption>
     </figure>
 
     <!-- link only -->
     <div class="mt-2 mb-3" *ngIf="url && !image">
-      <a [href]="url" target="__blank" class="text-muted"> [link] </a>
+      <a [href]="url" target="_blank" rel="noreferrer noopener" class="text-muted">
+        [link]
+      </a>
     </div>
 
     <!-- image only -->
     <figure class="mt-2 mb-4" *ngIf="!url && image">
-      <img [src]="image?.src" [alt]="image?.alt" class="w-100 image-responsive" />
+      <img [src]="image?.src" [alt]="image?.alt" />
       <figcaption>{{ image?.caption }}</figcaption>
     </figure>
 

--- a/src/app/shared/social-media-icon/social-media-icon.component.html
+++ b/src/app/shared/social-media-icon/social-media-icon.component.html
@@ -3,6 +3,7 @@
     *ngIf="network.name !== 'Email'; else email"
     [href]="network.url"
     target="_blank"
+    rel="noreferrer noopener"
     [title]="network.name"
   >
     <i [class]="network.icon"></i>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -74,6 +74,15 @@ a:active {
   color: $dark-blue !important;
 }
 
+img {
+  @extend .img-fluid;
+}
+
+figure img {
+  display: block;
+  margin: auto;
+}
+
 figcaption {
   @extend .text-muted;
   @extend .small;


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #91 

## Description

<!-- Describe what exactly you made (the task) and why it's important -->
All current external links (`<a>` tags) have `target="_blank" rel="noopener noreferrer"` to open the link in a new tab and prevent any security breaches related to that - all new links created should have that also.

From now on, it's not necessary to add `.img-fluid` to `<img>` tags, as it'll be done automatically to every image.

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - Add `target="_blank" rel="noopener noreferrer"` to every `<a>` tag that was missing it
 - Add `.img-fluid` to all images in the project in `styless.scss`
 - Make an `<img>` inside a `<figure>` be centered by default
 - Remove `.img-fluid .w-100 .image-responsive` in all images where it was now unnecessary