### PR TITLE
 ImageGridComponent's images are in <a> even without link

### DIFF
--- a/src/app/shared/image-grid/image-grid.component.html
+++ b/src/app/shared/image-grid/image-grid.component.html
@@ -2,9 +2,12 @@
   <div class="col-12 col-sm-6 col-md-4 col-lg-3 p-0" *ngFor="let item of gridItems">
     <div *ngIf="!item.modal; else showModal">
       <figure class="d-block m-auto">
-        <a [href]="item.url" target="_blank" rel="noreferrer noopener">
+        <a *ngIf="item.url" [href]="item.url" target="_blank" rel="noreferrer noopener">
           <img [src]="item.image.src" [alt]="item.image.alt" />
         </a>
+
+        <img *ngIf="!item.url" [src]="item.image.src" [alt]="item.image.alt" />
+
         <figcaption
           *ngIf="item.image.caption"
           [innerHTML]="item.image.caption | sanitizeHtml"


### PR DESCRIPTION
<!-- Substitute <ISSUE_NUMBER> by the task's actual issue number. -->
Fixes #131

## Description

<!-- Describe what exactly you made (the task) and why it's important -->
Even if the image had no associated URL, it was displayed inside an `<a>` tag. This PR fixes that.

## Changes

In order complete the task, I propose the following changes:

<!-- Describe the changes you made to complete the task, in bulletpoints. -->
 - Add `*ngIf` to only display image inside `<a>` if there is an URL